### PR TITLE
Version bump (v0.2.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-check-duplicates",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Bookshelf plugin that checks if there's a duplicate in a database",
   "main": "index.js",
   "directories": {
@@ -19,6 +19,7 @@
     "duplicates"
   ],
   "author": "Jaka Hudoklin",
+  "contributors": ["cumul <gg6123@naver.com>"],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/GateHubNet/bookshelf-check-duplicates/issues"


### PR DESCRIPTION
Version bump is needed for npm publish. See also #6.